### PR TITLE
Fix WGSL struct syntax for shader modules

### DIFF
--- a/src/shaders/fullscreen.wgsl
+++ b/src/shaders/fullscreen.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
-  @builtin(position) position : vec4<f32>;
-  @location(0) uv : vec2<f32>;
+  @builtin(position) position : vec4<f32>,
+  @location(0) uv : vec2<f32>,
 };
 
 @vertex

--- a/src/shaders/pathtrace.wgsl
+++ b/src/shaders/pathtrace.wgsl
@@ -1,29 +1,29 @@
 struct SceneUniforms {
-  invViewProj : mat4x4<f32>;
-  cameraPos : vec3<f32>;
-  frameIndex : u32;
-  lightDir : vec3<f32>;
-  objectCount : u32;
-  resolution : vec2<f32>;
-  maxBounces : u32;
-  environment : f32;
+  invViewProj : mat4x4<f32>,
+  cameraPos : vec3<f32>,
+  frameIndex : u32,
+  lightDir : vec3<f32>,
+  objectCount : u32,
+  resolution : vec2<f32>,
+  maxBounces : u32,
+  environment : f32,
 };
 
 struct Box {
-  min : vec3<f32>;
-  _pad0 : f32;
-  max : vec3<f32>;
-  _pad1 : f32;
-  color : vec3<f32>;
-  emission : f32;
+  min : vec3<f32>,
+  _pad0 : f32,
+  max : vec3<f32>,
+  _pad1 : f32,
+  color : vec3<f32>,
+  emission : f32,
 };
 
 struct HitInfo {
-  distance : f32;
-  normal : vec3<f32>;
-  color : vec3<f32>;
-  emission : f32;
-  hit : bool;
+  distance : f32,
+  normal : vec3<f32>,
+  color : vec3<f32>,
+  emission : f32,
+  hit : bool,
 };
 
 @group(0) @binding(0) var<uniform> scene : SceneUniforms;
@@ -44,9 +44,9 @@ fn safeInv(v : f32) -> f32 {
 }
 
 struct Intersection {
-  hit : bool;
-  distance : f32;
-  normal : vec3<f32>;
+  hit : bool,
+  distance : f32,
+  normal : vec3<f32>,
 };
 
 fn intersectBox(origin : vec3<f32>, dir : vec3<f32>, minB : vec3<f32>, maxB : vec3<f32>) -> Intersection {

--- a/src/shaders/solid.wgsl
+++ b/src/shaders/solid.wgsl
@@ -1,16 +1,16 @@
 struct SceneUniforms {
-  viewProj : mat4x4<f32>;
-  lightDir : vec4<f32>;
-  cameraPos : vec4<f32>;
+  viewProj : mat4x4<f32>,
+  lightDir : vec4<f32>,
+  cameraPos : vec4<f32>,
 };
 
 @group(0) @binding(0) var<uniform> scene : SceneUniforms;
 
 struct VSOutput {
-  @builtin(position) position : vec4<f32>;
-  @location(0) worldPos : vec3<f32>;
-  @location(1) normal : vec3<f32>;
-  @location(2) color : vec3<f32>;
+  @builtin(position) position : vec4<f32>,
+  @location(0) worldPos : vec3<f32>,
+  @location(1) normal : vec3<f32>,
+  @location(2) color : vec3<f32>,
 };
 
 @vertex


### PR DESCRIPTION
## Summary
- replace semicolons with commas in WGSL struct declarations so the shaders parse correctly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce023796f083298876649fccbf1980