### PR TITLE
Add full chess logic and touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
           <div id="check-indicator" class="status"></div>
           <div class="controls">
             <button id="reset-btn" type="button">Reset Game</button>
-            <span class="hint">Left click to select, drag right mouse to orbit.</span>
+            <span class="hint">
+              Click or tap to select pieces. Drag with the right mouse button or a single
+              finger to orbit, use two fingers to pan, and pinch to zoom.
+            </span>
           </div>
         </div>
       </header>

--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,7 @@ main {
   width: 100%;
   height: 100%;
   display: block;
+  touch-action: none;
 }
 
 .sidebar {


### PR DESCRIPTION
## Summary
- add castling, en passant, and enhanced history tracking to the chess engine
- add pointer and touch gesture handling, including multi-touch camera controls and rook move highlights
- update UI instructions and canvas touch behaviour for mobile players

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ce0380f8848329a6208045c3b40398